### PR TITLE
Ajout des parcelles uniquement EDIGEO

### DIFF
--- a/script/qgis/views/qgisParcelle.sql
+++ b/script/qgis/views/qgisParcelle.sql
@@ -36,17 +36,18 @@ CREATE MATERIALIZED VIEW #schema_cadastrapp.parcelle AS
 		parcelle.dcntpa
  	 FROM dblink('host=#DBHost_qgis dbname=#DBName_qgis user=#DBUser_qgis password=#DBpasswd_qgis'::text,
  		'select 
-			parcelle,
-			ccodep||ccodir||ccocom as cgocommune,
-			ltrim(dnupla, ''0'') as dnupla,
-			ltrim(dnvoiri, ''0'') as dnvoiri,
-			dindic,
-			cconvo,
-			rtrim(dvoilib),
-			ltrim(ccopre),
-			ltrim(ccosec),
-			dcntpa
-		from #DBSchema_qgis.parcelle'::text)
+			COALESCE(parcelle.parcelle,geo_parcelle.geo_parcelle) as parcelle,
+			COALESCE(parcelle.ccodep||parcelle.ccodir||parcelle.ccocom,ltrim(substr(geo_parcelle.geo_parcelle,5,6),''0'')) as cgocommune,
+			COALESCE(ltrim(parcelle.dnupla, ''0''),geo_parcelle.tex) as dnupla,
+			ltrim(parcelle.dnvoiri, ''0'') as dnvoiri,
+			parcelle.dindic,
+			parcelle.cconvo,
+			rtrim(parcelle.dvoilib),
+			COALESCE(ltrim(parcelle.ccopre),ltrim(substr(geo_parcelle.geo_parcelle,11,3),''0'')) as ccopre,
+			COALESCE(ltrim(ccosec),ltrim(substr(geo_parcelle.geo_parcelle,14,2),''0'')) as ccosec,
+			COALESCE(parcelle.dcntpa,CAST(geo_parcelle.supf AS integer)) as dcntpa
+		from #DBSchema_qgis.parcelle
+		full outer join #DBSchema_qgis.geo_parcelle on parcelle.parcelle = geo_parcelle.geo_parcelle'::text)
 	parcelle(
 		parcelle character varying(19), 
 		cgocommune character varying(6), 


### PR DESCRIPTION
Utilisation d'un FULL OUTER JOIN et de COALESCE pour que si une parcelle est absente de la table parcelle mais présente dans la table geo_parcelle, celle-ci soit tout de même prise en compte avec les attributs manquants dans le EDIGEO à NULL.

Il faudra faire la même modif sur le script Arcopole.

Ceci est une simplification éliminant la table intermediaire de https://github.com/georchestra/cadastrapp/pull/291

La finalité étant de pouvoir remonter des parcelles uniquement présentes dans le EDIGEO.

Il faudra en revanche voir comment l'addon arrive à gérer le cas ou une parcelle existe dans la vue mais ne dispose pas d'infos derrière.